### PR TITLE
Removed icon and label from manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.pnikosis.materialishprogress">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher">
-
-    </application>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" 
+    package="com.pnikosis.materialishprogress">
+    
+    <application />
 </manifest>


### PR DESCRIPTION
Removed icon and label from the AndroidManifest.xml of the library since 
a) it's not needed
b) if the library is added with gradle, it will produce this error, which can be fixed easily but it's easier to just remove it from the library: 

```
Error:(47, 9) Attribute application@icon value=(@drawable/ic_launcher) from AndroidManifest.xml
Error:(48, 9) Attribute application@label value=(@string/app_name) from AndroidManifest.xml
    is also present at com.pnikosis:materialish-progress:1.0:14:9 value=(@string/app_name)
    Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml to override
```
