### PR TITLE
Update typo in comments, changing dp to pixel

### DIFF
--- a/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java
+++ b/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java
@@ -32,7 +32,7 @@ public class ProgressWheel extends View {
      * DEFAULTS *
      * **********
      */
-    //Sizes (with defaults in DP)
+    //Sizes (with defaults in pixels)
     private int circleRadius = 28;
     private int barWidth = 4;
     private int rimWidth = 4;


### PR DESCRIPTION
Default values are in pixels, such as circleRadius and barWidth as defined at 28 and 4 respectively. This is confirmed by setCircleRadius (https://github.com/pnikosis/materialish-progress/blob/master/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java#L568) saying, "@param circleRadius the expected radius, in pixels" and setBarWidth (https://github.com/pnikosis/materialish-progress/blob/master/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java#L587) saying, "@param barWidth the spinning bar width in pixels" Unsure whether this was the intended behavior.