### PR TITLE
Adjust upper bound handling

### DIFF
--- a/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java
+++ b/library/src/main/java/com/pnikosis/materialishprogress/ProgressWheel.java
@@ -434,9 +434,9 @@ public class ProgressWheel extends View {
         }
 
         if (progress > 1.0f) {
-            progress -= 1.0f;
-        } else if (progress < 0) {
-            progress = 0;
+            progress = 1.0f;
+        } else if (progress < 0.0f) {
+            progress = 0.0f;
         }
 
         if (progress == mTargetProgress) {


### PR DESCRIPTION
If progress is more than 1.0f, rather than subtract 1.0f, we set progress at the upper bound max of 1.0f. Mirroring lower bound handling of setting to the lower bound of 0. Not urgent as Math.min properly handles.