### PR TITLE
Remove support library dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
 }
 
 apply from: '../maven_push.gradle'


### PR DESCRIPTION
This support library is unused and adds 0.5mb to the final build.